### PR TITLE
fix to SyncCtoStats->addStartStat()

### DIFF
--- a/system/modules/syncCto/SyncCtoStats.php
+++ b/system/modules/syncCto/SyncCtoStats.php
@@ -143,14 +143,17 @@ class SyncCtoStats extends Backend
     {
         // Clean sync options
         $arrSyncOptions = array();
-        foreach ($arrOptions['post_data'] as $key => $value)
-        {
-            if (in_array($key, $this->arrSkippedValues))
+        
+        if (isset($arrOptions['post_data'])) {
+            foreach ($arrOptions['post_data'] as $key => $value)
             {
-                continue;
-            }
-
-            $arrSyncOptions[$key] = $value;
+                if (in_array($key, $this->arrSkippedValues))
+                {
+                    continue;
+                }
+    
+                $arrSyncOptions[$key] = $value;
+            }   
         }
 
         // Build set array


### PR DESCRIPTION
if 'post_data' was missing in $arrOptions it throwed an error
