### PR TITLE
Use array_key_exists instead of key_exists

### DIFF
--- a/system/modules/syncCto/SyncCtoHelper.php
+++ b/system/modules/syncCto/SyncCtoHelper.php
@@ -667,7 +667,7 @@ class SyncCtoHelper extends Backend
                 }
                 else
                 {
-                    if (is_array($_SESSION["TL_INFO"]) && key_exists($val, $_SESSION["TL_INFO"]))
+                    if (is_array($_SESSION["TL_INFO"]) && array_key_exists($val, $_SESSION["TL_INFO"]))
                     {
                         unset($_SESSION["TL_INFO"][$val]);
                     }

--- a/system/modules/syncCto/SyncCtoModuleClient.php
+++ b/system/modules/syncCto/SyncCtoModuleClient.php
@@ -4583,7 +4583,7 @@ class SyncCtoModuleClient extends BackendModule
 
                 case 3:
 
-                    if (($this->arrSyncSettings['automode'] || key_exists("forward", $_POST)) && !(count($this->arrSyncSettings['syncCto_SyncTables']) == 0 && count($this->arrSyncSettings['syncCto_SyncDeleteTables']) == 0))
+                    if (($this->arrSyncSettings['automode'] || array_key_exists("forward", $_POST)) && !(count($this->arrSyncSettings['syncCto_SyncTables']) == 0 && count($this->arrSyncSettings['syncCto_SyncDeleteTables']) == 0))
                     {
                         // Go to next step
                         $this->objData->setState(SyncCtoEnum::WORK_WORK);
@@ -4593,7 +4593,7 @@ class SyncCtoModuleClient extends BackendModule
 
                         break;
                     }
-                    else if (($this->arrSyncSettings['automode'] || key_exists("forward", $_POST)) && count($this->arrSyncSettings['syncCto_SyncTables']) == 0 && count($this->arrSyncSettings['syncCto_SyncDeleteTables']) == 0)
+                    else if (($this->arrSyncSettings['automode'] || array_key_exists("forward", $_POST)) && count($this->arrSyncSettings['syncCto_SyncTables']) == 0 && count($this->arrSyncSettings['syncCto_SyncDeleteTables']) == 0)
                     {
                         // Skip if no tables are selected
                         $this->objData->setState(SyncCtoEnum::WORK_SKIPPED);

--- a/system/modules/syncCto/SyncCtoPopupDB.php
+++ b/system/modules/syncCto/SyncCtoPopupDB.php
@@ -143,13 +143,13 @@ class SyncCtoPopupDB extends Backend
             // Remove tables from the list.
             foreach ($arrRemoveTables as $value)
             {
-                if (isset($this->arrSyncSettings['syncCto_CompareTables']['recommended']) && key_exists($value, $this->arrSyncSettings['syncCto_CompareTables']['recommended']))
+                if (isset($this->arrSyncSettings['syncCto_CompareTables']['recommended']) && array_key_exists($value, $this->arrSyncSettings['syncCto_CompareTables']['recommended']))
                 {
                     unset($this->arrSyncSettings['syncCto_CompareTables']['recommended'][$value]);
                 }
                 else
                 {
-                    if (isset($this->arrSyncSettings['syncCto_CompareTables']['nonRecommended']) && key_exists($value, $this->arrSyncSettings['syncCto_CompareTables']['nonRecommended']))
+                    if (isset($this->arrSyncSettings['syncCto_CompareTables']['nonRecommended']) && array_key_exists($value, $this->arrSyncSettings['syncCto_CompareTables']['nonRecommended']))
                     {
                         unset($this->arrSyncSettings['syncCto_CompareTables']['nonRecommended'][$value]);
                     }
@@ -257,7 +257,7 @@ class SyncCtoPopupDB extends Backend
         }
 
         // Make a lookup in synccto language files
-        if (is_array($GLOBALS['TL_LANG']['tl_syncCto_database']) && key_exists($strName, $GLOBALS['TL_LANG']['tl_syncCto_database']))
+        if (is_array($GLOBALS['TL_LANG']['tl_syncCto_database']) && array_key_exists($strName, $GLOBALS['TL_LANG']['tl_syncCto_database']))
         {
             if (is_array($GLOBALS['TL_LANG']['tl_syncCto_database'][$strName]))
             {
@@ -302,7 +302,7 @@ class SyncCtoPopupDB extends Backend
         }
 
         // Little mapping for names        
-        if (is_array($GLOBALS['SYC_CONFIG']['database_mapping']) && key_exists($strName, $GLOBALS['SYC_CONFIG']['database_mapping']))
+        if (is_array($GLOBALS['SYC_CONFIG']['database_mapping']) && array_key_exists($strName, $GLOBALS['SYC_CONFIG']['database_mapping']))
         {
             $strRealSystemName = $GLOBALS['SYC_CONFIG']['database_mapping'][$strName];
 


### PR DESCRIPTION
The method (or alias)

``` php
bool key_exists ( mixed $key , array $array )
```

is deprecated and should be replaced by 

``` php
bool array_key_exists ( mixed $key , array $array )
```

More information here: http://php.net/manual/en/function.key-exists.php
