### PR TITLE
Fixed a bug with PHP memory_limit=-1

### DIFF
--- a/system/modules/syncCto/SyncCtoModuleClient.php
+++ b/system/modules/syncCto/SyncCtoModuleClient.php
@@ -5403,6 +5403,11 @@ class SyncCtoModuleClient extends BackendModule
      */
     static public function parseSize($size)
     {
+        if ($size == -1)
+        {
+            return PHP_INT_MAX;
+        }
+
         $size = trim($size);
         $last = strtolower($size[strlen($size) - 1]);
         switch ($last)


### PR DESCRIPTION
This commit fixes a bug with PHP memory_limit = -1 setting.

read more here: 
http://php.net/manual/en/ini.core.php#ini.memory-limit

>This sets the maximum amount of memory in bytes that a script is allowed to allocate. This helps prevent poorly written scripts for eating up all available memory on a server. Note that to have no memory limit, set this directive to -1.