### PR TITLE
Changed \String::* calls to \StringUtil for PHP7 compatibility reasons

### DIFF
--- a/system/modules/syncCto/SyncCtoFiles.php
+++ b/system/modules/syncCto/SyncCtoFiles.php
@@ -272,7 +272,7 @@ class SyncCtoFiles extends \Backend
 
             // PHP 7 compatibility
             // See #309 (https://github.com/contao/core-bundle/issues/309)
-            if (version_compare('3.5.5', VERSION, '>='))
+            if (version_compare('3.5.5', VERSION . '.' . BUILD, '>='))
             {
                 $arrModelData['uuid']      = \StringUtil::binToUuid($arrModelData['uuid']);
                 $arrModelData['pid']       = (strlen($arrModelData['pid'])) ? \StringUtil::binToUuid($arrModelData['pid']) : $arrModelData['pid'];
@@ -300,7 +300,7 @@ class SyncCtoFiles extends \Backend
 
             // PHP 7 compatibility
             // See #309 (https://github.com/contao/core-bundle/issues/309)
-            if (version_compare('3.5.5', VERSION, '>='))
+            if (version_compare('3.5.5', VERSION . '.' . BUILD, '>='))
             {
                 $arrModelData['uuid']      = \StringUtil::binToUuid($arrModelData['uuid']);
                 $arrModelData['pid']       = (strlen($arrModelData['pid'])) ? \StringUtil::binToUuid($arrModelData['pid']) : $arrModelData['pid'];
@@ -353,7 +353,7 @@ class SyncCtoFiles extends \Backend
 
             // PHP 7 compatibility
             // See #309 (https://github.com/contao/core-bundle/issues/309)
-            if (version_compare('3.5.5', VERSION, '>='))
+            if (version_compare('3.5.5', VERSION . '.' . BUILD, '>='))
             {
                 $arrModelData['uuid'] = \StringUtil::binToUuid($arrModelData['uuid']);
                 $arrModelData['pid']  = (strlen($arrModelData['pid'])) ? \StringUtil::binToUuid($arrModelData['pid']) : $arrModelData['pid'];
@@ -524,7 +524,7 @@ class SyncCtoFiles extends \Backend
 
                     // PHP 7 compatibility
                     // See #309 (https://github.com/contao/core-bundle/issues/309)
-                    if (version_compare('3.5.5', VERSION, '>='))
+                    if (version_compare('3.5.5', VERSION . '.' . BUILD, '>='))
                     {
                         $objLocaleData->uuid = \StringUtil::uuidToBin($arrFile['tl_files']['uuid']);
                     }
@@ -1780,7 +1780,7 @@ class SyncCtoFiles extends \Backend
 
                             // PHP 7 compatibility
                             // See #309 (https://github.com/contao/core-bundle/issues/309)
-                            if (version_compare('3.5.5', VERSION, '>='))
+                            if (version_compare('3.5.5', VERSION . '.' . BUILD, '>='))
                             {
                                 $objLocaleData->uuid = \StringUtil::uuidToBin($value['tl_files']['uuid']);
                             }
@@ -1802,7 +1802,7 @@ class SyncCtoFiles extends \Backend
                     {
                         // PHP 7 compatibility
                         // See #309 (https://github.com/contao/core-bundle/issues/309)
-                        if (version_compare('3.5.5', VERSION, '>='))
+                        if (version_compare('3.5.5', VERSION . '.' . BUILD, '>='))
                         {
                             // Get the readable UUID for the work.
                             $strLocaleUUID = \StringUtil::binToUuid($objLocaleData->uuid);
@@ -1872,7 +1872,7 @@ class SyncCtoFiles extends \Backend
 
                                 // PHP 7 compatibility
                                 // See #309 (https://github.com/contao/core-bundle/issues/309)
-                                if (version_compare('3.5.5', VERSION, '>='))
+                                if (version_compare('3.5.5', VERSION . '.' . BUILD, '>='))
                                 {
                                     $objLocaleData->uuid = \StringUtil::uuidToBin($value['tl_files']['uuid']);
                                 }

--- a/system/modules/syncCto/SyncCtoFiles.php
+++ b/system/modules/syncCto/SyncCtoFiles.php
@@ -269,8 +269,21 @@ class SyncCtoFiles extends \Backend
         {
             $objModel                      = \Dbafs::addResource(str_replace('\\\\', '/', $strFilePath));
             $arrModelData                  = $objModel->row();
-            $arrModelData['uuid']          = \String::binToUuid($arrModelData['uuid']);
-            $arrModelData['pid']           = (strlen($arrModelData['pid'])) ? \String::binToUuid($arrModelData['pid']) : $arrModelData['pid'];
+
+            // PHP 7 compatibility
+            // See #309 (https://github.com/contao/core-bundle/issues/309)
+            if (version_compare('3.5.5', VERSION, '>='))
+            {
+                $arrModelData['uuid']      = \StringUtil::binToUuid($arrModelData['uuid']);
+                $arrModelData['pid']       = (strlen($arrModelData['pid'])) ? \StringUtil::binToUuid($arrModelData['pid']) : $arrModelData['pid'];
+            }
+
+            else
+            {
+                $arrModelData['uuid']      = \String::binToUuid($arrModelData['uuid']);
+                $arrModelData['pid']       = (strlen($arrModelData['pid'])) ? \String::binToUuid($arrModelData['pid']) : $arrModelData['pid'];
+            }
+
             $arrModelData['tail']          = $this->getDbafsTailFor($arrModelData['pid']);
 
             return $arrModelData;
@@ -284,8 +297,21 @@ class SyncCtoFiles extends \Backend
         else
         {
             $arrModelData                  = $objModel->row();
-            $arrModelData['uuid']          = \String::binToUuid($arrModelData['uuid']);
-            $arrModelData['pid']           = (strlen($arrModelData['pid'])) ? \String::binToUuid($arrModelData['pid']) : $arrModelData['pid'];
+
+            // PHP 7 compatibility
+            // See #309 (https://github.com/contao/core-bundle/issues/309)
+            if (version_compare('3.5.5', VERSION, '>='))
+            {
+                $arrModelData['uuid']      = \StringUtil::binToUuid($arrModelData['uuid']);
+                $arrModelData['pid']       = (strlen($arrModelData['pid'])) ? \StringUtil::binToUuid($arrModelData['pid']) : $arrModelData['pid'];
+            }
+
+            else
+            {
+                $arrModelData['uuid']      = \String::binToUuid($arrModelData['uuid']);
+                $arrModelData['pid']       = (strlen($arrModelData['pid'])) ? \String::binToUuid($arrModelData['pid']) : $arrModelData['pid'];
+            }
+
             $arrModelData['tail']          = $this->getDbafsTailFor($arrModelData['pid']);
 
             return $arrModelData;
@@ -324,8 +350,20 @@ class SyncCtoFiles extends \Backend
 
             // Bin to string cast.
             $arrModelData         = $objModel->row();
-            $arrModelData['uuid'] = \String::binToUuid($arrModelData['uuid']);
-            $arrModelData['pid']  = (strlen($arrModelData['pid'])) ? \String::binToUuid($arrModelData['pid']) : $arrModelData['pid'];
+
+            // PHP 7 compatibility
+            // See #309 (https://github.com/contao/core-bundle/issues/309)
+            if (version_compare('3.5.5', VERSION, '>='))
+            {
+                $arrModelData['uuid'] = \StringUtil::binToUuid($arrModelData['uuid']);
+                $arrModelData['pid']  = (strlen($arrModelData['pid'])) ? \StringUtil::binToUuid($arrModelData['pid']) : $arrModelData['pid'];
+            }
+
+            else
+            {
+                $arrModelData['uuid'] = \String::binToUuid($arrModelData['uuid']);
+                $arrModelData['pid']  = (strlen($arrModelData['pid'])) ? \String::binToUuid($arrModelData['pid']) : $arrModelData['pid'];
+            }
 
             // Save to the array.
             $arrTail[$mixPID] = $arrModelData;
@@ -483,7 +521,18 @@ class SyncCtoFiles extends \Backend
 
                     // First add it to the dbafs.
                     $objLocaleData       = \Dbafs::addResource($arrFile['path']);
-                    $objLocaleData->uuid = \String::uuidToBin($arrFile['tl_files']['uuid']);
+
+                    // PHP 7 compatibility
+                    // See #309 (https://github.com/contao/core-bundle/issues/309)
+                    if (version_compare('3.5.5', VERSION, '>='))
+                    {
+                        $objLocaleData->uuid = \StringUtil::uuidToBin($arrFile['tl_files']['uuid']);
+                    }
+
+                    else
+                    {
+                        $objLocaleData->uuid = \String::uuidToBin($arrFile['tl_files']['uuid']);
+                    }
                     $objLocaleData->meta = $arrFile['tl_files']['meta'];
                     $objLocaleData->save();
 
@@ -1728,7 +1777,19 @@ class SyncCtoFiles extends \Backend
                         {
                             // First add it to the dbafs.
                             $objLocaleData       = \Dbafs::addResource($strFileDestination);
-                            $objLocaleData->uuid = \String::uuidToBin($value['tl_files']['uuid']);
+
+                            // PHP 7 compatibility
+                            // See #309 (https://github.com/contao/core-bundle/issues/309)
+                            if (version_compare('3.5.5', VERSION, '>='))
+                            {
+                                $objLocaleData->uuid = \StringUtil::uuidToBin($value['tl_files']['uuid']);
+                            }
+
+                            else
+                            {
+                                $objLocaleData->uuid = \String::uuidToBin($value['tl_files']['uuid']);
+                            }
+
                             $objLocaleData->meta = $value['tl_files']['meta'];
                             $objLocaleData->save();
 
@@ -1739,8 +1800,19 @@ class SyncCtoFiles extends \Backend
                     }
                     else
                     {
-                        // Get the readable UUID for the work.
-                        $strLocaleUUID = \String::binToUuid($objLocaleData->uuid);
+                        // PHP 7 compatibility
+                        // See #309 (https://github.com/contao/core-bundle/issues/309)
+                        if (version_compare('3.5.5', VERSION, '>='))
+                        {
+                            // Get the readable UUID for the work.
+                            $strLocaleUUID = \StringUtil::binToUuid($objLocaleData->uuid);
+                        }
+
+                        else
+                        {
+                            // Get the readable UUID for the work.
+                            $strLocaleUUID = \String::binToUuid($objLocaleData->uuid);
+                        }
 
                         // Okay it seems we have already a file with this values.
                         if ($strLocaleUUID == $value['tl_files']['uuid'])
@@ -1797,7 +1869,19 @@ class SyncCtoFiles extends \Backend
                             {
                                 // First add it to the dbafs.
                                 $objLocaleData       = \Dbafs::addResource($strFileDestination);
-                                $objLocaleData->uuid = \String::uuidToBin($value['tl_files']['uuid']);
+
+                                // PHP 7 compatibility
+                                // See #309 (https://github.com/contao/core-bundle/issues/309)
+                                if (version_compare('3.5.5', VERSION, '>='))
+                                {
+                                    $objLocaleData->uuid = \StringUtil::uuidToBin($value['tl_files']['uuid']);
+                                }
+
+                                else
+                                {
+                                    $objLocaleData->uuid = \String::uuidToBin($value['tl_files']['uuid']);
+                                }
+
                                 $objLocaleData->meta = $value['tl_files']['meta'];
                                 $objLocaleData->save();
 

--- a/system/modules/syncCto/SyncCtoModuleClient.php
+++ b/system/modules/syncCto/SyncCtoModuleClient.php
@@ -3059,16 +3059,40 @@ class SyncCtoModuleClient extends \BackendModule
                                 if ($objModel != null)
                                 {
                                     $arrModelData         = $objModel->row();
-                                    $arrModelData['pid']  = (strlen($arrModelData['pid'])) ? \String::binToUuid($arrModelData['pid']) : $arrModelData['pid'];
-                                    $arrModelData['uuid'] = \String::binToUuid($arrModelData['uuid']);
+
+                                    // PHP 7 compatibility
+                                    // See #309 (https://github.com/contao/core-bundle/issues/309)
+                                    if (version_compare('3.5.5', VERSION, '>='))
+                                    {
+                                        $arrModelData['pid']  = (strlen($arrModelData['pid'])) ? \StringUtil::binToUuid($arrModelData['pid']) : $arrModelData['pid'];
+                                        $arrModelData['uuid'] = \StringUtil::binToUuid($arrModelData['uuid']);
+                                    }
+
+                                    else
+                                    {
+                                        $arrModelData['pid']  = (strlen($arrModelData['pid'])) ? \String::binToUuid($arrModelData['pid']) : $arrModelData['pid'];
+                                        $arrModelData['uuid'] = \String::binToUuid($arrModelData['uuid']);
+                                    }
                                 }
                                 // if not add it to the current DBAFS.
                                 else
                                 {
                                     $objModel             = \Dbafs::addResource($value['path']);
                                     $arrModelData         = $objModel->row();
-                                    $arrModelData['pid']  = (strlen($arrModelData['pid'])) ? \String::binToUuid($arrModelData['pid']) : $arrModelData['pid'];
-                                    $arrModelData['uuid'] = \String::binToUuid($arrModelData['uuid']);
+
+                                    // PHP 7 compatibility
+                                    // See #309 (https://github.com/contao/core-bundle/issues/309)
+                                    if (version_compare('3.5.5', VERSION, '>='))
+                                    {
+                                        $arrModelData['pid']  = (strlen($arrModelData['pid'])) ? \StringUtil::binToUuid($arrModelData['pid']) : $arrModelData['pid'];
+                                        $arrModelData['uuid'] = \StringUtil::binToUuid($arrModelData['uuid']);
+                                    }
+
+                                    else
+                                    {
+                                        $arrModelData['pid']  = (strlen($arrModelData['pid'])) ? \String::binToUuid($arrModelData['pid']) : $arrModelData['pid'];
+                                        $arrModelData['uuid'] = \String::binToUuid($arrModelData['uuid']);
+                                    }
                                 }
 
                                 $itSupSet[ $key ]['tl_files'] = $arrModelData;

--- a/system/modules/syncCto/SyncCtoModuleClient.php
+++ b/system/modules/syncCto/SyncCtoModuleClient.php
@@ -3062,7 +3062,7 @@ class SyncCtoModuleClient extends \BackendModule
 
                                     // PHP 7 compatibility
                                     // See #309 (https://github.com/contao/core-bundle/issues/309)
-                                    if (version_compare('3.5.5', VERSION, '>='))
+                                    if (version_compare('3.5.5', VERSION . '.' . BUILD, '>='))
                                     {
                                         $arrModelData['pid']  = (strlen($arrModelData['pid'])) ? \StringUtil::binToUuid($arrModelData['pid']) : $arrModelData['pid'];
                                         $arrModelData['uuid'] = \StringUtil::binToUuid($arrModelData['uuid']);
@@ -3082,7 +3082,7 @@ class SyncCtoModuleClient extends \BackendModule
 
                                     // PHP 7 compatibility
                                     // See #309 (https://github.com/contao/core-bundle/issues/309)
-                                    if (version_compare('3.5.5', VERSION, '>='))
+                                    if (version_compare('3.5.5', VERSION . '.' . BUILD, '>='))
                                     {
                                         $arrModelData['pid']  = (strlen($arrModelData['pid'])) ? \StringUtil::binToUuid($arrModelData['pid']) : $arrModelData['pid'];
                                         $arrModelData['uuid'] = \StringUtil::binToUuid($arrModelData['uuid']);


### PR DESCRIPTION
PHP 7 compatibility - see contao/core-bundle#309.